### PR TITLE
Fix typo in metadata tags

### DIFF
--- a/src/data/events-optimized.json
+++ b/src/data/events-optimized.json
@@ -3,7 +3,7 @@
   "created_at": "2025-05-29T12:00:00.000Z",
   "metadata": {
     "total_events": 7,
-    "tags": ["abenteuer", "ankunft", "arena", "erfolgn", "erkundung", "fest", "gefahr", "goblins", "information", "kampf", "neue-stadt", "npc", "quest", "reise", "ruine", "schatz", "turnier"],
+    "tags": ["abenteuer", "ankunft", "arena", "erfolg", "erkundung", "fest", "gefahr", "goblins", "information", "kampf", "neue-stadt", "npc", "quest", "reise", "ruine", "schatz", "turnier"],
     "date_range": {
       "start": "2024-03-15",
       "end": "2024-05-15"


### PR DESCRIPTION
## Summary
- fix typo `erfolgn` -> `erfolg` in events data

## Testing
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('src/data/events-optimized.json','utf8')); console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_6840128d1844832e86af45b09f77ad0b