### PR TITLE
Implement cache invalidation and validation fix

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -345,7 +345,7 @@ const Timeline = () => {
       };
       
       // Validate event data before adding
-      const validation = EventValidator.validate(eventToAdd);
+      const validation = EventValidator.validateEvent(eventToAdd);
       if (!validation.isValid) {
         showNotification(`Event-Daten sind ungültig: ${validation.errors.join(', ')}`, 'error');
         return;
@@ -379,7 +379,7 @@ const Timeline = () => {
 
   const handleSaveEdit = useCallback((updatedEvent) => {
     // Validate updated event data
-    const validation = EventValidator.validate(updatedEvent);
+    const validation = EventValidator.validateEvent(updatedEvent);
     if (!validation.isValid) {
       showNotification(`Event-Daten sind ungültig: ${validation.errors.join(', ')}`, 'error');
       return;

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -427,6 +427,11 @@ export class EventCollection {
     this._tagCache = null;
   }
 
+  _invalidateCache() {
+    this._sortedByDate = null;
+    this._tagCache = null;
+  }
+
   add(eventData) {
     const event = eventData instanceof OptimizedEvent ? eventData : new OptimizedEvent(eventData);
     this.events.push(event);


### PR DESCRIPTION
## Summary
- add `_invalidateCache` helper to `EventCollection`
- update validation calls in `Timeline` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68401293b99c832e950a2a6762a77521