### PR TITLE
Add Jest setup and validation tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "electron-dev": "concurrently \"npm run dev\" \"wait-on http://localhost:5173 && electron .\"",
     "build-electron": "npm run build && electron-builder",
     "build-mac": "npm run build && electron-builder --mac",
-    "dist": "npm run build && electron-builder --publish=never"
+    "dist": "npm run build && electron-builder --publish=never",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "classnames": "^2.5.1",
@@ -42,7 +43,8 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.8",
     "vite": "^6.3.5",
-    "wait-on": "^8.0.3"
+    "wait-on": "^8.0.3",
+    "jest": "^29.7.0"
   },
   "build": {
     "appId": "com.maxbohn.pen-paper-timeline",

--- a/src/utils/__tests__/eventUtils.test.js
+++ b/src/utils/__tests__/eventUtils.test.js
@@ -1,0 +1,44 @@
+import { EventValidator } from '../eventUtils.js';
+
+describe('EventValidator.validateEvent', () => {
+  test('valid event returns isValid true', () => {
+    const result = EventValidator.validateEvent({
+      name: 'Test',
+      description: 'desc',
+      entry_date: '2024-01-01',
+      entry_time: '12:00'
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('missing name returns error', () => {
+    const result = EventValidator.validateEvent({
+      description: 'desc',
+      entry_date: '2024-01-01',
+      entry_time: '12:00'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Event name is required');
+  });
+
+  test('missing date returns error', () => {
+    const result = EventValidator.validateEvent({
+      name: 'Test',
+      description: 'desc',
+      entry_time: '12:00'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Event date is required');
+  });
+
+  test('missing time returns error', () => {
+    const result = EventValidator.validateEvent({
+      name: 'Test',
+      description: 'desc',
+      entry_date: '2024-01-01'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('Event time is required');
+  });
+});


### PR DESCRIPTION
## Summary
- add `test` script and jest devDependency
- create basic `jest.config.js`
- write unit tests for EventValidator

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684012976968832e8619acdba575d0a4