### PR TITLE
Add settings modal and improve search

### DIFF
--- a/src/components/SearchResultCard.jsx
+++ b/src/components/SearchResultCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BadgeCheck, Search, Tag, Info, Star } from 'lucide-react';
+import { BadgeCheck, Search, Tag, Info, Star, Calendar, MapPin } from 'lucide-react';
 
 // Helper to highlight matched terms in text
 function highlightMatches(text, matches) {
@@ -85,6 +85,9 @@ const SearchResultCard = ({ event, matches = [], score = null, onClick }) => {
         {event.tags && event.tags.length > 0 && event.tags.map((tag, i) => (
           <span key={i} className="inline-flex items-center bg-blue-100 text-blue-800 rounded px-2 py-0.5 mr-1"><Tag size={12} className="mr-1" />{tag}</span>
         ))}
+        {event.entry_date && (
+          <span className="inline-flex items-center"><Calendar size={14} className="mr-1" />{event.entry_date} {event.entry_time}</span>
+        )}
       </div>
       <div className="flex flex-wrap gap-1 mt-1">
         {/* Show unique match types as badges */}

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+
+const SettingsModal = ({ isDarkMode, autoSaveInterval, onAutoSaveIntervalChange, onToggleDarkMode, onClose }) => {
+  const [interval, setInterval] = useState(Math.round(autoSaveInterval / 1000));
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const valueMs = Math.max(500, parseInt(interval, 10) * 1000);
+    onAutoSaveIntervalChange(valueMs);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className={`rounded-2xl shadow-2xl max-w-sm w-full p-6 ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xl font-bold">Einstellungen</h3>
+          <button
+            onClick={onClose}
+            className={`p-2 rounded-lg ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'}`}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Auto-Save Intervall (Sekunden)</label>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={interval}
+              onChange={(e) => setInterval(e.target.value)}
+              className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent ${isDarkMode ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300'}`}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="dark-mode-toggle"
+              type="checkbox"
+              checked={isDarkMode}
+              onChange={onToggleDarkMode}
+              className="mr-2"
+            />
+            <label htmlFor="dark-mode-toggle" className="text-sm">Dunkelmodus aktivieren</label>
+          </div>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className={`px-4 py-2 rounded-lg ${isDarkMode ? 'text-gray-300 hover:bg-gray-700' : 'text-gray-600 hover:bg-gray-100'}`}
+            >
+              Abbrechen
+            </button>
+            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+              Speichern
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -32,6 +32,7 @@ import CurrentGameTimePicker from './CurrentGameTimePicker';
 import UnifiedTimeNavigator from './UnifiedTimeNavigator';
 import logger from '../utils/logger';
 import SearchResultCard from './SearchResultCard';
+import SettingsModal from './SettingsModal';
 import debounce from 'lodash.debounce';
 
 const Timeline = () => {
@@ -47,6 +48,8 @@ const Timeline = () => {
   const [selectedTags, setSelectedTags] = useState([]);
   const [isDarkMode, setIsDarkMode] = useState(false);
   const [notification, setNotification] = useState(null);
+  const [showSettings, setShowSettings] = useState(false);
+  const [autoSaveInterval, setAutoSaveInterval] = useState(1000);
   const [newEvent, setNewEvent] = useState({
     name: '',
     entry_date: '',
@@ -93,6 +96,7 @@ const Timeline = () => {
         // Load saved preferences from localStorage (non-critical data)
         const savedTime = localStorage.getItem('timeline-current-time');
         const savedDarkMode = localStorage.getItem('timeline-dark-mode');
+        const savedInterval = localStorage.getItem('timeline-autosave');
         
         if (savedTime) {
           try {
@@ -104,6 +108,10 @@ const Timeline = () => {
 
         if (savedDarkMode === 'true') {
           setIsDarkMode(true);
+        }
+        if (savedInterval) {
+          const val = parseInt(savedInterval, 10);
+          if (!isNaN(val)) setAutoSaveInterval(val);
         }
 
       } catch (error) {
@@ -181,12 +189,13 @@ const Timeline = () => {
       
       // Save non-critical data to localStorage
       localStorage.setItem('timeline-current-time', currentGameTime.toISOString());
+      localStorage.setItem('timeline-autosave', autoSaveInterval.toString());
     };
 
     // Debounce saves to avoid too frequent writes
-    const timeoutId = setTimeout(saveData, 1000);
+    const timeoutId = setTimeout(saveData, autoSaveInterval);
     return () => clearTimeout(timeoutId);
-  }, [eventCollection, currentGameTime]);
+  }, [eventCollection, currentGameTime, autoSaveInterval]);
 
   // Debounce searchTerm updates
   useEffect(() => {
@@ -529,6 +538,16 @@ const Timeline = () => {
         />
       )}
 
+      {showSettings && (
+        <SettingsModal
+          isDarkMode={isDarkMode}
+          autoSaveInterval={autoSaveInterval}
+          onAutoSaveIntervalChange={setAutoSaveInterval}
+          onToggleDarkMode={toggleDarkMode}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+
       {/* Notification System */}
       {notification && (
         <div className={`fixed top-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg transition-all duration-300 ${
@@ -766,6 +785,19 @@ const Timeline = () => {
                   aria-label="Datenordner öffnen"
                 >
                   <Folder className="w-4 h-4" />
+                </button>
+
+                <button
+                  onClick={() => setShowSettings(true)}
+                  className={`p-2 rounded-xl transition-colors ${
+                    isDarkMode
+                      ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                  title="Einstellungen"
+                  aria-label="Einstellungen"
+                >
+                  <Settings className="w-4 h-4" />
                 </button>
 
                 <button

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -14,6 +14,7 @@ export class OptimizedEvent {
     this.tags = Array.isArray(data.tags) ? data.tags : [];
     this.created_at = data.created_at || new Date().toISOString();
     this.updated_at = data.updated_at || new Date().toISOString();
+    this._searchCache = null;
   }
 
   getStartDateTime() {
@@ -58,13 +59,24 @@ export class OptimizedEvent {
   }
 
   getSearchableText() {
-    return {
-      name: this.name || '',
-      description: this.description || '',
-      location: this.location || '',
-      tags: this.tags || [],
-      combined: [this.name, this.description, this.location, ...this.tags].filter(Boolean).join(' ').toLowerCase()
-    };
+    if (!this._searchCache) {
+      this._searchCache = {
+        name: this.name || '',
+        description: this.description || '',
+        location: this.location || '',
+        tags: this.tags || [],
+        combined: [
+          this.name,
+          this.description,
+          this.location,
+          ...(this.tags || [])
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+      };
+    }
+    return this._searchCache;
   }
 
   getSearchScore(searchTerm, selectedTags = []) {
@@ -394,6 +406,7 @@ export class OptimizedEvent {
 
   update(data) {
     Object.assign(this, data);
+    this._searchCache = null;
     this.updated_at = new Date().toISOString();
     return this;
   }


### PR DESCRIPTION
## Summary
- add cached search data for events
- enhance SearchResultCard with date info
- create SettingsModal for adjusting options
- integrate settings into Timeline with autosave interval

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_684016d116a0832ea1172109e28aecaf