### PR TITLE
Add end time validation test

### DIFF
--- a/src/utils/__tests__/eventUtils.test.js
+++ b/src/utils/__tests__/eventUtils.test.js
@@ -41,4 +41,18 @@ describe('EventValidator.validateEvent', () => {
     expect(result.isValid).toBe(false);
     expect(result.errors).toContain('Event time is required');
   });
+
+  test('end date/time before start returns error', () => {
+    const result = EventValidator.validateEvent({
+      name: 'Test',
+      description: 'desc',
+      entry_date: '2024-01-02',
+      entry_time: '12:00',
+      hasEndDateTime: true,
+      end_date: '2024-01-01',
+      end_time: '11:00'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toContain('End date/time must be after start date/time');
+  });
 });


### PR DESCRIPTION
## Summary
- cover invalid end date/time scenario in `validateEvent`

## Testing
- `npm test` *(fails: Cannot find module 'jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68405a533420832ea7e10f19dea8465b