### PR TITLE
Use matches field in search results

### DIFF
--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -543,7 +543,7 @@ export class EventCollection {
         scoredEvents.push({
           event,
           score: finalScore,
-          matchDetails: includeScoring ? scoreResult.matchDetails : undefined
+          matches: includeScoring ? scoreResult.matches : undefined
         });
       }
     });
@@ -573,7 +573,7 @@ export class EventCollection {
           fallbackEvents.push({
             event,
             score: fallbackScore,
-            matchDetails: [{ type: 'super_fuzzy_fallback', value: searchTerm, matched: bestWord, distance: minDistance, score: fallbackScore }]
+            matches: [{ type: 'super_fuzzy_fallback', value: searchTerm, matched: bestWord, distance: minDistance, score: fallbackScore }]
           });
         }
       });


### PR DESCRIPTION
## Summary
- use `matches` from search scoring results
- keep fallback search info under the same property

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68405a4d2de8832eaf75076b8d385214