### PR TITLE
Fix search overlay and time navigator styles

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -711,11 +711,13 @@ const Timeline = () => {
                 
                 {/* Search Tips Tooltip */}
                 {searchTerm.length === 0 && isSearchFocused && (
-                  <div className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-lg text-xs ${
-                    isDarkMode 
-                      ? 'bg-gray-800/95 border-gray-600 text-gray-300' 
-                      : 'bg-blue-50/95 border-blue-200 text-blue-800'
-                  }`}>
+                  <div
+                    className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-xl backdrop-blur-md z-50 text-xs ${
+                      isDarkMode
+                        ? 'bg-gray-800/95 border-gray-600 text-gray-300'
+                        : 'bg-blue-50/90 border-blue-200 text-blue-800'
+                    }`}
+                  >
                     <div className="font-medium mb-1">🚀 KI-Powered Search Features:</div>
                     <ul className="space-y-1">
                       <li>• 🧠 "Gobblin Angrif" → "Goblin Angriff" (Fuzzy-Match)</li>

--- a/src/components/UnifiedTimeNavigator.jsx
+++ b/src/components/UnifiedTimeNavigator.jsx
@@ -135,11 +135,13 @@ const UnifiedTimeNavigator = ({
   };
 
   return (
-    <div className={`p-4 rounded-xl backdrop-blur-sm border transition-all duration-300 ${
-      isDarkMode 
-        ? 'bg-gray-800/40 border-gray-700/50' 
-        : 'bg-white/60 border-gray-200/50'
-    } ${className}`}>
+    <div
+      className={`relative z-10 p-4 rounded-xl backdrop-blur-md border shadow-2xl ring-1 ring-black/5 transition-all duration-300 ${
+        isDarkMode
+          ? 'bg-gray-800/40 border-gray-700/50'
+          : 'bg-white/70 border-gray-200/50'
+      } ${className}`}
+    >
       
       {/* Unit Selector - Compact horizontal */}
       <div className="flex justify-center gap-1 mb-4">


### PR DESCRIPTION
## Summary
- keep search tips tooltip above timeline navigator
- add subtle blur & shadow effects for a cleaner look

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68406477bdb0832e91ddb48002d8257b