### PR TITLE
Implement modal animations and zoomable list

### DIFF
--- a/src/components/EditEventForm.tsx
+++ b/src/components/EditEventForm.tsx
@@ -1,5 +1,5 @@
 // EditEventForm.jsx - Modal form for editing events
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, Plus } from 'lucide-react';
 import DateTimePicker from './DateTimePicker';
 import { EventValidator } from '../utils/eventUtils';
@@ -22,6 +22,17 @@ const EditEventForm = ({ event, isDarkMode, currentGameTime, onSave, onCancel }:
   });
   const [newTag, setNewTag] = useState('');
   const [validationErrors, setValidationErrors] = useState([]);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 10);
+    return () => clearTimeout(t);
+  }, []);
+
+  const handleClose = () => {
+    setVisible(false);
+    setTimeout(onCancel, 300);
+  };
 
   const addTag = () => {
     if (newTag.trim() && !editData.tags.includes(newTag.trim())) {
@@ -74,14 +85,20 @@ const EditEventForm = ({ event, isDarkMode, currentGameTime, onSave, onCancel }:
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className={`rounded-2xl shadow-2xl max-w-md w-full p-6 transition-colors duration-300 ${
-        isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'
-      }`}>
+    <div
+      className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div
+        className={`rounded-2xl shadow-2xl max-w-md w-full p-6 transition-colors transform duration-300 ${
+          visible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        } ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}
+      >
         <div className="flex items-center justify-between mb-6">
           <h3 className="text-xl font-bold">Event bearbeiten</h3>
           <button
-            onClick={onCancel}
+            onClick={handleClose}
             className={`p-2 rounded-lg transition-colors ${
               isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'
             }`}
@@ -221,9 +238,9 @@ const EditEventForm = ({ event, isDarkMode, currentGameTime, onSave, onCancel }:
           <div className="flex justify-end gap-3 pt-4">
             <button
               type="button"
-              onClick={onCancel}
+              onClick={handleClose}
               className={`px-4 py-2 rounded-lg transition-colors ${
-                isDarkMode 
+                isDarkMode
                   ? 'text-gray-300 hover:bg-gray-700'
                   : 'text-gray-600 hover:bg-gray-100'
               }`}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,23 +1,43 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 
 const SettingsModal = ({ isDarkMode, autoSaveInterval, onAutoSaveIntervalChange, onToggleDarkMode, onClose }) => {
   const [interval, setInterval] = useState(Math.round(autoSaveInterval / 1000));
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger fade-in when mounted
+    const t = setTimeout(() => setVisible(true), 10);
+    return () => clearTimeout(t);
+  }, []);
+
+  const handleClose = () => {
+    setVisible(false);
+    setTimeout(onClose, 300);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const valueMs = Math.max(500, parseInt(interval, 10) * 1000);
     onAutoSaveIntervalChange(valueMs);
-    onClose();
+    handleClose();
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className={`rounded-2xl shadow-2xl max-w-sm w-full p-6 ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}>
+    <div
+      className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${
+        visible ? 'opacity-100' : 'opacity-0'
+      }`}
+    >
+      <div
+        className={`rounded-2xl shadow-2xl max-w-sm w-full p-6 transform transition-all duration-300 ${
+          visible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+        } ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}
+      >
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-xl font-bold">Einstellungen</h3>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             className={`p-2 rounded-lg ${isDarkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'}`}
           >
             <X className="w-5 h-5" />

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -72,8 +72,9 @@ const Timeline = () => {
   const listRef = useRef(null);
   const sizeMap = useRef({});
   const [listHeight, setListHeight] = useState(600);
+  const [zoomLevel, setZoomLevel] = useState(1);
 
-  const getItemSize = index => sizeMap.current[index] || 300;
+  const getItemSize = index => (sizeMap.current[index] || 300) * zoomLevel;
 
   const setItemSize = (index, size) => {
     if (sizeMap.current[index] !== size) {
@@ -83,6 +84,12 @@ const Timeline = () => {
       }
     }
   };
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.resetAfterIndex(0, true);
+    }
+  }, [zoomLevel]);
 
   useEffect(() => {
     const updateHeight = () => {
@@ -512,7 +519,7 @@ const Timeline = () => {
 
     const ref = useCallback(node => {
       if (node) {
-        const height = node.getBoundingClientRect().height;
+        const height = node.offsetHeight;
         setItemSize(index, height);
       }
     }, [index]);
@@ -619,21 +626,24 @@ const Timeline = () => {
                       <span className="font-medium">
                         Aktuelle Zeit: {currentGameTime.toLocaleDateString('de-DE')} {currentGameTime.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
                       </span>
-                      <button
-                        onClick={() => setIsEditingTime(true)}
-                        className={`p-1 rounded transition-colors ${
-                          isDarkMode 
-                            ? 'text-gray-400 hover:bg-gray-700 hover:text-white'
-                            : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
-                        }`}
-                        title="Zeit bearbeiten"
-                      >
-                        <Edit3 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  )}
+                  <button
+                    onClick={() => setIsEditingTime(true)}
+                    className={`p-1 rounded transition-colors ${
+                      isDarkMode
+                        ? 'text-gray-400 hover:bg-gray-700 hover:text-white'
+                        : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                    }`}
+                    title="Zeit bearbeiten"
+                  >
+                    <Edit3 className="w-4 h-4" />
+                  </button>
                 </div>
+                <span className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                  Zoom: {Math.round(zoomLevel * 100)}%
+                </span>
+                )}
               </div>
+            </div>
             </div>
 
             {/* Search, Filter and Controls */}
@@ -955,16 +965,30 @@ const Timeline = () => {
               )}
             </div>
           ) : (
-            <List
-              height={listHeight}
-              itemCount={filteredAndSortedEventsWithScores.length}
-              itemSize={getItemSize}
-              width="100%"
-              ref={listRef}
-              className="space-y-0 overflow-auto"
+            <div
+              onWheel={(e) => {
+                if (e.ctrlKey) {
+                  e.preventDefault();
+                  setZoomLevel((z) => {
+                    const next = z - e.deltaY * 0.001;
+                    return Math.min(2, Math.max(0.5, next));
+                  });
+                }
+              }}
             >
-              {Row}
-            </List>
+              <div style={{ transform: `scale(${zoomLevel})`, transformOrigin: 'top left' }}>
+                <List
+                  height={listHeight / zoomLevel}
+                  itemCount={filteredAndSortedEventsWithScores.length}
+                  itemSize={getItemSize}
+                  width="100%"
+                  ref={listRef}
+                  className="space-y-0 overflow-auto"
+                >
+                  {Row}
+                </List>
+              </div>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add fade-in/out animations to SettingsModal and EditEventForm
- implement zoom level state for Timeline using mousewheel and show zoom percentage
- adjust list item sizing to respect zoom level

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm test` *(fails: Cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_6840672acfc4832eac665a560c948021