### PR TITLE
Fix search dropdown overlap

### DIFF
--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -753,7 +753,7 @@ const Timeline = () => {
                 {/* Search Suggestions Dropdown */}
                 {searchSuggestions.length > 0 && searchTerm.length >= 2 && (
                   <div
-                    className={`absolute top-full left-0 right-0 mt-1 border rounded-xl shadow-lg z-50 max-h-48 overflow-y-auto ${
+                    className={`absolute top-full left-0 right-0 mt-1 border rounded-xl shadow-lg z-[60] max-h-48 overflow-y-auto ${
                       isDarkMode
                         ? 'bg-gray-800 border-gray-600'
                         : 'bg-white border-gray-200'
@@ -795,9 +795,9 @@ const Timeline = () => {
                 
                 {/* Freundlicher Platzhalter/Tooltip */}
                 {searchTerm.length === 0 && isSearchFocused && (
-                  <div className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-lg text-sm ${
-                    isDarkMode 
-                      ? 'bg-gray-800/95 border-gray-600 text-gray-200' 
+                  <div className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-lg text-sm z-[60] ${
+                    isDarkMode
+                      ? 'bg-gray-800/95 border-gray-600 text-gray-200'
                       : 'bg-blue-50/95 border-blue-200 text-blue-900'
                   }`}>
                     <div className="font-semibold mb-1">🔎 Suche nach Abenteuern, Orten, NPCs oder Tags!</div>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -640,7 +640,7 @@ const Timeline = () => {
                 {/* Search Suggestions Dropdown */}
                 {searchSuggestions.length > 0 && searchTerm.length >= 2 && (
                   <div
-                    className={`absolute top-full left-0 right-0 mt-1 border rounded-xl shadow-lg z-50 max-h-48 overflow-y-auto ${
+                    className={`absolute top-full left-0 right-0 mt-1 border rounded-xl shadow-lg z-[60] max-h-48 overflow-y-auto ${
                       isDarkMode
                         ? 'glass-dark'
                         : 'glass-light'
@@ -683,7 +683,7 @@ const Timeline = () => {
                 {/* Search Tips Tooltip */}
                 {searchTerm.length === 0 && isSearchFocused && (
                   <div
-                    className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-lg z-50 text-xs ${
+                    className={`absolute top-full left-0 right-0 mt-1 p-3 border rounded-xl shadow-lg z-[60] text-xs ${
                       isDarkMode
                         ? 'glass-dark text-gray-200'
                         : 'glass-light text-gray-800'


### PR DESCRIPTION
## Summary
- bump z-index for search suggestion elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6841be5686b8832eb47897d32032e76d