### PR TITLE
Fix modal overlap with time switcher

### DIFF
--- a/src/components/EditEventForm.jsx
+++ b/src/components/EditEventForm.jsx
@@ -73,7 +73,7 @@ const EditEventForm = ({ event, isDarkMode, currentGameTime, onSave, onCancel, i
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
       <div className={`rounded-2xl shadow-2xl max-w-md w-full p-6 transition-colors duration-300 ${
         isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'
       }`}>

--- a/src/components/SettingsModal.jsx
+++ b/src/components/SettingsModal.jsx
@@ -12,7 +12,7 @@ const SettingsModal = ({ isDarkMode, autoSaveInterval, onAutoSaveIntervalChange,
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4">
       <div className={`rounded-2xl shadow-2xl max-w-sm w-full p-6 ${isDarkMode ? 'bg-gray-800 text-white' : 'bg-white text-gray-900'}`}>
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-xl font-bold">Einstellungen</h3>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -25,7 +25,7 @@ const SettingsModal = ({ isDarkMode, autoSaveInterval, onAutoSaveIntervalChange,
 
   return (
     <div
-      className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 transition-opacity duration-300 ${
+      className={`fixed inset-0 bg-black/50 backdrop-blur-sm z-[70] flex items-center justify-center p-4 transition-opacity duration-300 ${
         visible ? 'opacity-100' : 'opacity-0'
       }`}
     >


### PR DESCRIPTION
## Summary
- raise overlay z-index for `EditEventForm`
- raise overlay z-index for `SettingsModal` in JS/TS variants

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6841c181704c832eb0863e9d04cea0e3