### PR TITLE
Fix edit event form overlay

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -426,7 +426,7 @@ const Timeline = () => {
   }, [eventCollection, showNotification]);
 
   const handleEditEvent = useCallback((event) => {
-    setEditingEvent(event.id);
+    setEditingEvent(event);
   }, []);
 
   const handleSaveEdit = useCallback((updatedEvent) => {
@@ -526,6 +526,16 @@ const Timeline = () => {
           currentGameTime={currentGameTime}
           onSave={handleAddEvent}
           onCancel={() => setShowAddForm(false)}
+        />
+      )}
+
+      {editingEvent && (
+        <EditEventForm
+          event={editingEvent}
+          isDarkMode={isDarkMode}
+          currentGameTime={currentGameTime}
+          onSave={handleSaveEdit}
+          onCancel={() => setEditingEvent(null)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- open EditEventForm as a standalone overlay instead of inline
- update handler to store selected event object

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6841c3a09000832ebd8332872a46d2bc